### PR TITLE
Optionally import authorised keys from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ The following attributes are required for each user:
 * ssh_key - This should be a list of SSH keys for the user (optional). Each SSH key
   should be included directly and should have no newlines.
 * generate_ssh_key - Whether to generate a SSH key for the user (optional, defaults to no).
-* github_username - Installs ssh_keys from github username.keys
 
 In addition, the following items are optional for each user:
 
+* github_username - Installs ssh_keys from github username.keys
 * shell - The user's shell. This defaults to /bin/bash. The default is
   configurable using the users_default_shell variable if you want to give all
   users the same shell, but it is different than /bin/bash.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
     user: "{{ item.username }}"
     key: "https://github.com/{{ item.github_username }}.keys"
   with_items: "{{ users }}"
+  when: "'github_username' in item"
 
 
 - name: Setup user profiles


### PR DESCRIPTION
Allows creating users without specifying a GitHub username